### PR TITLE
Updated ChallengeGUI

### DIFF
--- a/src/unlockABox/ChallengeGUI.java
+++ b/src/unlockABox/ChallengeGUI.java
@@ -20,6 +20,8 @@ import javax.swing.JTextArea;
 import java.awt.event.ActionListener;
 import java.util.Scanner;
 import java.awt.event.ActionEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 
 public class ChallengeGUI extends JFrame
 {
@@ -154,8 +156,8 @@ public class ChallengeGUI extends JFrame
 		JPanel pnlTxtSubmit = new JPanel();
 		pnlInfo.add(pnlTxtSubmit);
 		txtBoxGetUserInput = new JTextField();
-
 		pnlTxtSubmit.add(txtBoxGetUserInput);
+		
 		txtBoxGetUserInput.setActionCommand("");
 		txtBoxGetUserInput.setName("");
 		txtBoxGetUserInput.setToolTipText("Input Answer");
@@ -213,6 +215,22 @@ public class ChallengeGUI extends JFrame
 				 */
 				setVisible(false);
 				dispose();
+			}
+		});
+		
+		/**
+		 * When user clicks on textbox after inputting data, textbox will clear previous input
+		 * Picture will default to original image for the challenge
+		 * Incorrect/Correct text will default to no text
+		 */
+		txtBoxGetUserInput.addMouseListener(new MouseAdapter() {
+			@Override
+			public void mouseClicked(MouseEvent arg0) 
+			{
+				txtBoxGetUserInput.setText("");
+				valid.setText("");
+				lblPicture.setIcon(new ImageIcon(Challenge.class.getResource(lock.getImage())));
+				pnlChallenge.add(lblPicture);
 			}
 		});
 


### PR DESCRIPTION
After clicking submit, user can click on TextBox. User's previous input
in TextBox will be deleted automatically and the picture will revert to
the initial image for the challenge. Label "incorrect or correct" will
also revert.


Code Added:

		/**
		 * When user clicks on textbox after inputting data, textbox will clear previous input
		 * Picture will default to original image for the challenge
		 * Incorrect/Correct text will default to no text
		 */
		txtBoxGetUserInput.addMouseListener(new MouseAdapter() {
			@Override
			public void mouseClicked(MouseEvent arg0) 
			{
				txtBoxGetUserInput.setText("");
				valid.setText("");
				lblPicture.setIcon(new ImageIcon(Challenge.class.getResource(lock.getImage())));
				pnlChallenge.add(lblPicture);
			}
		});